### PR TITLE
詳細表示機能の実装

### DIFF
--- a/app/assets/stylesheets/events/index.scss
+++ b/app/assets/stylesheets/events/index.scss
@@ -9,6 +9,7 @@
 
 .calendar {
   width: calc(100vw - 300px);
+  height: 100vh;
 }
 
 .event-form {

--- a/app/assets/stylesheets/shared/calendar.css
+++ b/app/assets/stylesheets/shared/calendar.css
@@ -1,0 +1,28 @@
+.simple-calendar {
+}
+
+.day {
+}
+.wday-0 {}
+.wday-1 {}
+.wday-2 {}
+.wday-3 {}
+.wday-4 {}
+.wday-5 {}
+.wday-6 {}
+
+.today {}
+.past {}
+.future {}
+
+.start-date {}
+
+.prev-month {}
+.next-month {}
+.current-month {}
+
+.has-events {}
+
+table {
+  height: calc(100vh - 42px);
+} 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,6 +19,11 @@ class EventsController < ApplicationController
     end
   end
 
+  def show
+    @events = Event.all
+    @event = Event.find(params[:id])
+  end
+
   private
 
   def event_params

--- a/app/views/events/_calendar.html.erb
+++ b/app/views/events/_calendar.html.erb
@@ -4,7 +4,7 @@
 
   <% events.each do |event| %>
     <div>
-      <%= link_to event.title, "#" %>
+      <%= link_to event.title, event_path(event.id) %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,31 @@
+<div class="wrapper">
+  <div class="side-bar">
+    <div class="show">
+    <p>
+      <strong>日にち</strong>
+      <%= @event.day %>
+    </p>
+    <p>
+      <strong>タイトル</strong>
+      <%= @event.title %>
+    </p>
+    <p>
+      <strong>内容</strong>
+      <%= @event.text %>
+    </p>
+    <p>
+      <strong>レベル</strong>
+      <%= @event.happy_level.name %>
+    </p>
+    <p>
+      <strong>公開/非公開</strong>
+      <%= @event.public.name %>
+    </p>
+    <%= link_to '戻る', events_path %>
+    </div>
+  </div>
+
+  <div class="calendar">
+    <%= render "calendar" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "events#index"
-  resources :events, only: [:index, :new, :create]
+  resources :events, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
# What
投稿詳細表示機能の実装として、一覧の投稿タイトルをクリックすると、投稿詳細表示ページに遷移して、投稿の詳細情報を表示するように実装した。

# Why
投稿詳細表示機能を実装するため。